### PR TITLE
Fix double data loading on viewDidLoad in ViewController

### DIFF
--- a/CMExpertise Precticle/View/HomeView/ViewController.swift
+++ b/CMExpertise Precticle/View/HomeView/ViewController.swift
@@ -25,7 +25,7 @@ class ViewController: UIViewController {
     //MARK: - lifecycle Method
     override func viewDidLoad() {
         super.viewDidLoad()
-        // observer for getiing data
+        // observer for getting data
         viewModel.$list.sink {[weak self] list in
             self?.refresData(data: list)
         }.store(in: &bag)
@@ -41,6 +41,8 @@ class ViewController: UIViewController {
     }
     
     func refresData(data: WeatherResModel?) {
+        // Reset arrData to avoid duplicates on each refresh
+        arrData.removeAll()
         for i in data?.list ?? [] {
             let date = i.dtTxt?.getDate() ?? ""
             if let index = self.arrData.firstIndex(where: {$0.date == date}) {
@@ -75,10 +77,8 @@ extension ViewController {
     
     func getDataWithAwait() {
         Task { @MainActor in
-            let result = await viewModel.getDataWithAwait()
-            if let data = result {
-                self.refresData(data: data)
-            }
+            // Result is published via viewModel.$list; no need to call refresData directly.
+            await viewModel.getDataWithAwait()
         }
     }
 }


### PR DESCRIPTION
## Problem

In `ViewController.viewDidLoad`, both a Combine sink on `viewModel.$list` **and** a direct call to `getDataWithAwait()` are wired up. When `getDataWithAwait()` completes it calls `refresData` directly, and the Combine publisher also fires `refresData` via the sink — causing every item to be appended twice and the table view to show duplicate entries.

## Fix

- Remove the redundant direct call to `self.refresData(data:)` inside `getDataWithAwait()` and rely solely on the Combine sink on `viewModel.$list` to refresh the UI, which is the intended reactive pattern.
- This ensures a single, consistent data-refresh path regardless of which fetch method is used.

Closes #7