### PR TITLE
Fix duplicate data in arrData by removing redundant refresData call

### DIFF
--- a/CMExpertise Precticle/View/HomeView/ViewController.swift
+++ b/CMExpertise Precticle/View/HomeView/ViewController.swift
@@ -41,6 +41,7 @@ class ViewController: UIViewController {
     }
     
     func refresData(data: WeatherResModel?) {
+        arrData.removeAll()
         for i in data?.list ?? [] {
             let date = i.dtTxt?.getDate() ?? ""
             if let index = self.arrData.firstIndex(where: {$0.date == date}) {
@@ -75,10 +76,7 @@ extension ViewController {
     
     func getDataWithAwait() {
         Task { @MainActor in
-            let result = await viewModel.getDataWithAwait()
-            if let data = result {
-                self.refresData(data: data)
-            }
+            await viewModel.getDataWithAwait()
         }
     }
 }


### PR DESCRIPTION
## Problem

The `ViewController` subscribes to `viewModel.$list` via Combine and calls `refresData` in the sink. However, `getDataWithAwait()` also calls `refresData` directly with the returned result, and the view model's `getDataWithAwait()` method also updates `viewModel.list`, triggering the sink a second time. This causes every entry to be appended twice into `arrData`.

## Fix

- Remove the direct `self.refresData(data: data)` call from the `getDataWithAwait()` Task block in `ViewController`, letting the Combine sink be the single source of truth for updating the UI.
- Clear `arrData` at the start of `refresData` to prevent stale data accumulation on refresh.

Closes #10